### PR TITLE
Make the stream operators inline to avoid compile errors

### DIFF
--- a/include/sdsl/uint128_t.hpp
+++ b/include/sdsl/uint128_t.hpp
@@ -29,6 +29,7 @@ namespace sdsl
 
 typedef unsigned int uint128_t __attribute__((mode(TI)));
 
+inline
 std::ostream& operator<<(std::ostream& os, const uint128_t& x)
 {
     uint64_t X[2] = {(uint64_t)(x >> 64), (uint64_t)x};

--- a/include/sdsl/uint256_t.hpp
+++ b/include/sdsl/uint256_t.hpp
@@ -169,7 +169,7 @@ class uint256_t
         }
 
         bool operator==(const uint256_t& x) const {
-            return (m_lo == x.m_lo) and (m_mid == x.m_mid) and (m_high == x.m_high);
+            return (m_lo == x.m_lo) and(m_mid == x.m_mid) and(m_high == x.m_high);
         }
 
         bool operator!=(const uint256_t& x) const {
@@ -232,6 +232,7 @@ class uint256_t
         }
 };
 
+inline
 std::ostream& operator<<(std::ostream& os, const uint256_t& x)
 {
     uint64_t X[4] = {(uint64_t)(x.m_high >> 64), (uint64_t)x.m_high, x.m_mid, x.m_lo};


### PR DESCRIPTION
the two stream operators implemented for the large unsigned data
types are implemented in the header files. to avoid compiler errors
they should be declared static or inline so they don't get exported
more than once if the files are included and compiled into multiple
object files.
